### PR TITLE
Add definitions for compatibility with other editors and objectdraw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ js/minigrace.js: js/minigrace.in.js
 	@cat js/minigrace.in.js > js/minigrace.js
 	@echo "MiniGrace.version = '$$(tools/calculate-version HEAD)';" >> js/minigrace.js
 	@echo "MiniGrace.revision = '$$(git rev-parse HEAD|cut -b1-7)';" >> js/minigrace.js
+	@cat js/gracelib.js >> js/minigrace.js
+	@cat `ls js/*.js | grep -v 'background\|gracelib\|minigrace\|node-server\|tabs'` >> js/minigrace.js
 
 js/sample-dialects js/sample-graphics: js/sample-%: js
 	$(MAKE) -C js/sample/$* VERBOSITY=$(VERBOSITY)

--- a/js/index.in.html
+++ b/js/index.in.html
@@ -4,37 +4,9 @@
     <meta http-equiv="Content-Type" content="text/html" charset="utf-8" />
     <title>Minigrace JavaScript backend</title>
     <link type="text/css" rel="stylesheet" href="global.css" />
-    
+
     <script src="minigrace.js" type="text/javascript"></script>
-    <script src="samples.js" type="text/javascript"></script>
     <script src="tabs.js" type="text/javascript"></script>
-    <script src="gracelib.js" type="text/javascript"></script>
-    <script src="dom.js" type="text/javascript"></script>
-    <script src="gtk.js" type="text/javascript"></script>
-    <script src="debugger.js" type="text/javascript"></script>
-    <script src="timer.js" type="text/javascript"></script>
-    <script src="collectionsPrelude.js" type="text/javascript"></script>
-    <script src="StandardPrelude.js" type="text/javascript"></script>
-    <script src="importStandardPrelude.js" type="text/javascript"></script>
-    <script src="compiler.js" type="text/javascript"></script>
-    <script src="lexer.js" type="text/javascript"></script>
-    <script src="ast.js" type="text/javascript"></script>
-    <script src="parser.js" type="text/javascript"></script>
-    <script src="genc.js" type="text/javascript"></script>
-    <script src="genjs.js" type="text/javascript"></script>
-    <script src="buildinfo.js" type="text/javascript"></script>
-    <script src="identifierresolution.js" type="text/javascript"></script>
-    <script src="genjson.js" type="text/javascript"></script>
-    <script src="collections.js" type="text/javascript"></script>
-    <script src="mgcollections.js" type="text/javascript"></script>
-    <script src="xmodule.js" type="text/javascript"></script>
-    <script src="unicodedata.js" type="text/javascript"></script>
-    <script src="errormessages.js" type="text/javascript"></script>
-    <script src="gUnit.js" type="text/javascript"></script>
-    <script src="sample/dialects/requireTypes.js" type="text/javascript"></script>
-    <script src="sample/dialects/staticTypes.js" type="text/javascript"></script>
-    <script src="objectdraw.js" type="text/javascript"></script>
-    <script src="rtobjectdraw.js" type="text/javascript"></script>
     <script src="ace/ace.js" type="text/javascript"></script>
     <script src="ace/mode-grace.js" type="text/javascript" charset="utf-8"></script>
 </head>


### PR DESCRIPTION
This adds many of the definitions which are necessary for objectdraw to function. It also tidies up some whitespace, and now produces a concatenated `minigrace.js` which should be compatible with more environments.