### PR TITLE
minigrace --target js now runs the executable.

### DIFF
--- a/genjs.grace
+++ b/genjs.grace
@@ -1080,12 +1080,11 @@ method compilevardec(o) {
     o.register := val
 }
 method compileindex(o) {
-    var of := compilenode(o.value)
-    var index := compilenode(o.index)
-    out("var idxres" ++ auto_count ++ " = " ++ of ++ ".methods[\"[]\"]"
-        ++ ".call(" ++ of ++ ", [1], " ++ index ++ ");")
+    def of = compilenode(o.value)
+    def index = compilenode(o.index)
     o.register := "idxres" ++ auto_count
     auto_count := auto_count + 1
+    out "var {o.register} = callmethod({of}, \"[]\", [1], {index})"
 }
 method compilecatchcase(o) {
     def myc = auto_count

--- a/genjs.grace
+++ b/genjs.grace
@@ -1649,8 +1649,7 @@ method compile(vl, of, mn, rm, bt, glpath) {
     outfile.close
     log_verbose("done.")
     if (buildtype == "run") then {
-        def cmd = "grace {of}"
-        def runExitCode = io.spawn(cmd).wait
+        def runExitCode = io.spawn("grace", of.pathname).wait
         if (runExitCode < 0) then {
             io.error.write "minigrace: Program {modname} exited with error {-runExitCode}.\n"
             sys.exit(4)

--- a/js/grace.in
+++ b/js/grace.in
@@ -204,6 +204,10 @@ function graceModuleName(fileName) {
 };
 
 function findOnPath(fn, pathArray) {
+    if (fn[0] === "/") {
+        if (fs.existsSync(fn)) { return fn };
+        throw new Error('file "' + fn + '" does not exist.');
+    }
     for (var ix = 0; ix < pathArray.length ; ix++) {
         var candidate = path.resolve(pathArray[ix], fn);  
             // path.resolve joins, normalizes, & makes absolute


### PR DESCRIPTION
Also fixes the bug where invoking a non-exitant [] method crashes the runtime.