### PR TITLE
Updated graphix.addText.draw to return self

### DIFF
--- a/modules/graphix.grace
+++ b/modules/graphix.grace
@@ -467,6 +467,7 @@ factory method create(canvasWidth, canvasHeight) {
         jsText.draw(content, font, color)
         stage.add(jsText)
         stage.update
+        self
       }
     }
     shapes.add(text)


### PR DESCRIPTION
This fix is for better chaining behavior