### PR TITLE
Type information stored in gct files, with tests

### DIFF
--- a/js/tests/t179_gctTypeInformation.out
+++ b/js/tests/t179_gctTypeInformation.out
@@ -1,0 +1,36 @@
+classes:
+confidential:
+fresh-methods:
+methodtypes-of:A:
+ :2 m1(n : Number) -> Number
+ :2 m2(n : Number) -> Done
+ :| 2
+ :| B<T>
+ :| other.C
+ :| other.U<T>
+methodtypes-of:D:
+ :& Collection<T>
+ :& F
+ :& G
+methodtypes-of:H<T>:
+ :2 m3(x : T) -> T
+methodtypes-of:Z:
+ :& 3
+ :& 4
+ :3 m4(x : Y) -> Y
+ :4 m5(x : Z) -> Z
+modules:
+path:
+ test179
+public:
+ A
+ D
+ H
+ Z
+ m
+types:
+ A
+ D
+ H
+ Z
+

--- a/js/tests/t179_gctTypeInformation.out
+++ b/js/tests/t179_gctTypeInformation.out
@@ -2,23 +2,23 @@ classes:
 confidential:
 fresh-methods:
 methodtypes-of:A:
- :2 m1(n : Number) -> Number
- :2 m2(n : Number) -> Done
- :| 2
- :| B<T>
- :| other.C
- :| other.U<T>
+ 2 m1(n : Number) -> Number
+ 2 m2(n : Number) -> Done
+ | 2
+ | B<T>
+ | other.C
+ | other.U<T>
 methodtypes-of:D:
- :& Collection<T>
- :& F
- :& G
+ & Collection<T>
+ & F
+ & G
 methodtypes-of:H<T>:
- :2 m3(x : T) -> T
+ 2 m3(x : T) -> T
 methodtypes-of:Z:
- :& 3
- :& 4
- :3 m4(x : Y) -> Y
- :4 m5(x : Z) -> Z
+ & 3
+ & 4
+ 3 m4(x : Y) -> Y
+ 4 m5(x : Z) -> Z
 modules:
 path:
  test179

--- a/js/tests/t179_gctTypeInformation_test.grace
+++ b/js/tests/t179_gctTypeInformation_test.grace
@@ -1,0 +1,34 @@
+import "lexer" as lexer
+import "parser" as parser
+import "util" as util
+import "xmodule" as xmodule
+
+def input = list.with(
+    "def x = 100",
+    "method m \{",
+    "    print(47)",
+    "\}",
+    "type A = B<T> | other.C | other.U<T> | type \{",
+    "    m1(n:Number) -> Number",
+    "    m2(n:Number) -> Done",
+    "\}",
+    "type D = Collection<T> & F & G",
+    "type H<T> = type \{",
+    "    m3(x:T) -> T",
+    "\}",
+    "type Z = type \{",
+    "    m4(x:Y) -> Y",
+    "\} & type \{",
+    "    m5(x:Z) -> Z",
+    "\}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+xmodule.writeGCT("test179")fromValues(nodes)modules(list.empty)
+def gct = xmodule.parseGCT("test179")
+def gctText = xmodule.gctAsString(gct)
+
+print (gctText)

--- a/tests/t179_gctTypeInformation.out
+++ b/tests/t179_gctTypeInformation.out
@@ -1,0 +1,36 @@
+classes:
+confidential:
+fresh-methods:
+methodtypes-of:A:
+ :2 m1(n : Number) -> Number
+ :2 m2(n : Number) -> Done
+ :| 2
+ :| B<T>
+ :| other.C
+ :| other.U<T>
+methodtypes-of:D:
+ :& Collection<T>
+ :& F
+ :& G
+methodtypes-of:H<T>:
+ :2 m3(x : T) -> T
+methodtypes-of:Z:
+ :& 3
+ :& 4
+ :3 m4(x : Y) -> Y
+ :4 m5(x : Z) -> Z
+modules:
+path:
+ test179
+public:
+ A
+ D
+ H
+ Z
+ m
+types:
+ A
+ D
+ H
+ Z
+

--- a/tests/t179_gctTypeInformation.out
+++ b/tests/t179_gctTypeInformation.out
@@ -2,23 +2,23 @@ classes:
 confidential:
 fresh-methods:
 methodtypes-of:A:
- :2 m1(n : Number) -> Number
- :2 m2(n : Number) -> Done
- :| 2
- :| B<T>
- :| other.C
- :| other.U<T>
+ 2 m1(n : Number) -> Number
+ 2 m2(n : Number) -> Done
+ | 2
+ | B<T>
+ | other.C
+ | other.U<T>
 methodtypes-of:D:
- :& Collection<T>
- :& F
- :& G
+ & Collection<T>
+ & F
+ & G
 methodtypes-of:H<T>:
- :2 m3(x : T) -> T
+ 2 m3(x : T) -> T
 methodtypes-of:Z:
- :& 3
- :& 4
- :3 m4(x : Y) -> Y
- :4 m5(x : Z) -> Z
+ & 3
+ & 4
+ 3 m4(x : Y) -> Y
+ 4 m5(x : Z) -> Z
 modules:
 path:
  test179

--- a/tests/t179_gctTypeInformation_test.grace
+++ b/tests/t179_gctTypeInformation_test.grace
@@ -1,0 +1,34 @@
+import "lexer" as lexer
+import "parser" as parser
+import "util" as util
+import "xmodule" as xmodule
+
+def input = list.with(
+    "def x = 100",
+    "method m \{",
+    "    print(47)",
+    "\}",
+    "type A = B<T> | other.C | other.U<T> | type \{",
+    "    m1(n:Number) -> Number",
+    "    m2(n:Number) -> Done",
+    "\}",
+    "type D = Collection<T> & F & G",
+    "type H<T> = type \{",
+    "    m3(x:T) -> T",
+    "\}",
+    "type Z = type \{",
+    "    m4(x:Y) -> Y",
+    "\} & type \{",
+    "    m5(x:Z) -> Z",
+    "\}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+xmodule.writeGCT("test179")fromValues(nodes)modules(list.empty)
+def gct = xmodule.parseGCT("test179")
+def gctText = xmodule.gctAsString(gct)
+
+print (gctText)

--- a/xmodule.grace
+++ b/xmodule.grace
@@ -259,7 +259,7 @@ def typeVisitor = object {
     var literalCount := 1
     method visitTypeLiteral(lit) {
         for (lit.methods) do { meth ->
-            var mtstr := ":{literalCount} "
+            var mtstr := "{literalCount} "
             for (meth.signature) do { part ->
                 mtstr := mtstr ++ part.name
                 if ((part.params.size > 0) || (part.vararg != false)) then {
@@ -307,20 +307,20 @@ def typeVisitor = object {
             def rightkind = op.right.kind
             if ((leftkind=="identifier") || (leftkind=="member")) then {
                 var typeIdent := op.left.toGrace(0)
-                methodtypes.push(":{op.value} {typeIdent}")
+                methodtypes.push("{op.value} {typeIdent}")
             } elseif(leftkind=="typeliteral") then {
                 literalCount := literalCount + 1
-                methodtypes.push(":{op.value} {literalCount}")
+                methodtypes.push("{op.value} {literalCount}")
                 visitTypeLiteral(op.left)
             } elseif (leftkind=="op") then {
                 visitOp(op.left)
             }
             if ((rightkind=="identifier") || (rightkind=="member")) then {
                 var typeIdent := op.right.toGrace(0)
-                methodtypes.push(":{op.value} {typeIdent}")
+                methodtypes.push("{op.value} {typeIdent}")
             } elseif(rightkind=="typeliteral") then {
                 literalCount := literalCount + 1
-                methodtypes.push(":{op.value} {literalCount}")
+                methodtypes.push("{op.value} {literalCount}")
                 visitTypeLiteral(op.right)
             } elseif (rightkind=="op") then {
                 visitOp(op.right)


### PR DESCRIPTION
Edited xmodule to retain type information in the gct file
for a compiled program. Added tests of this in tests/ and
js/tests/. Includes type expressions with & and |.