### PR TITLE
Corrected AST line numbers + GCT type info documentation

### DIFF
--- a/doc/gctTypes
+++ b/doc/gctTypes
@@ -46,13 +46,13 @@ literals:
      3 m4(x : Y) -> Y
      4 m5(x : Z) -> Z
 
-This means that type Z is a union type of two type literals, represented by 3
+This means that type Z is the & type of two type literals, represented by 3
 and 4. One type literal has only the method m4, and the other has only the 
 method m5. The actual values of these numbers are not significant; it only 
 matters that lines with different number prefixes are from different type
 literals.
 
-Finally, note how union types and variant types are prefixed with & or |. An
+Finally, note how & types and variant types are prefixed with & or |. An
 entry to the GCT that looks like this:
 
     methodtypes-of:D:
@@ -60,7 +60,7 @@ entry to the GCT that looks like this:
      & F
      & G
 
-...means that type D is a union of three types: Collection<T> & F & G. An entry
+...means that type D is the & type of three types: Collection<T> & F & G. An entry
 to the GCT that looks like this:
 
     methodtypes-of:A:

--- a/doc/gctTypes
+++ b/doc/gctTypes
@@ -1,0 +1,74 @@
+In order to type-check against types declared in imported modules, the GCT
+file for a compiled module contains information about the types in that module.
+The idea is to have just enough information in the GCT to allow for the types
+to be parsed and rebuilt completely as ObjectTypes by the static-types dialect.
+
+The GCT contains this type information with a list of all types declared in the
+module, and for each type a list of the type's methodtype signatures. The list
+of types in collectionsPrelude.gct looks like this:
+
+    types:
+     Binding
+     Block0
+     Block1
+     Block2
+     Collection
+     CollectionFactory
+     Dictionary
+     EmptyCollectionFactory
+     Enumerable
+     Iterator
+     List
+     SelfType
+     Sequence
+     Set
+
+Note that any generic parameters are left off in this type list. The list of
+methodtypes for Binding looks like this:
+
+    methodtypes-of:Binding<K, T>:
+     7 == -> Boolean
+     7 hash -> Number
+     7 key -> K
+     7 value -> T
+
+Note that the generic parameters are included here. The only part of the list
+of methodtypes that is not self-explanatory is the prefix on each line, which 
+is always either a &, a |, or a number. If the prefix of a line is a number, it
+means that that methodtype is listed within a type literal, and all other lines
+which are prefixed with the same number come from the same type literal. This
+is useful in cases like the following, where a type is composed of two type
+literals:
+
+    methodtypes-of:Z:
+     & 3
+     & 4
+     3 m4(x : Y) -> Y
+     4 m5(x : Z) -> Z
+
+This means that type Z is a union type of two type literals, represented by 3
+and 4. One type literal has only the method m4, and the other has only the 
+method m5. The actual values of these numbers are not significant; it only 
+matters that lines with different number prefixes are from different type
+literals.
+
+Finally, note how union types and variant types are prefixed with & or |. An
+entry to the GCT that looks like this:
+
+    methodtypes-of:D:
+     & Collection<T>
+     & F
+     & G
+
+...means that type D is a union of three types: Collection<T> & F & G. An entry
+to the GCT that looks like this:
+
+    methodtypes-of:A:
+     2 m1(n : Number) -> Number
+     2 m2(n : Number) -> Done
+     | 2
+     | B<T>
+     | other.C
+
+...means that type A is a variant type of B<T> | other.C | 2, where 2 is a type
+literal that contains two methods (m1 and m2).

--- a/js/tests/t180_astLineNumbers.out
+++ b/js/tests/t180_astLineNumbers.out
@@ -1,0 +1,53 @@
+1:1 typedec
+  1:6 identifierBinding‹Person›
+  Value:1:15 typeliteral
+      Types:
+      Methods:
+        2:3 methodtype
+          Name: age
+          Returns:
+            2:10 identifier‹Number›
+          Signature:
+            2:7 signaturepart: age
+              Parameters:
+        3:3 methodtype
+          Name: name
+          Returns:
+            3:11 identifier‹String›
+          Signature:
+            3:8 signaturepart: name
+              Parameters:
+
+
+5:0 blank
+6:2 class
+  Name: 6:7 identifierBinding‹person›
+  Factory method: 6:14 identifierBinding‹new›
+  Signature:
+    Part: new
+      Parameters:
+        6:18 identifierBinding‹name'›
+        6:25 identifierBinding‹age'›
+  Body:
+    7:3 defdec
+      7:7 identifierBinding‹name›
+      Value: 7:24 identifier‹name'›
+      Annotations: 7:15 identifier‹public›
+    8:3 defdec
+      8:7 identifierBinding‹age›
+      Value: 8:23 identifier‹age'›
+      Annotations: 8:14 identifier‹public›
+    9:1 method
+      Name: 9:10 identifierBinding‹getShoeSize›
+      Signature:
+        Part: getShoeSize
+          Parameters:
+      Body:
+        10:5 return
+          10:19 op‹+›
+            10:19 op‹*›
+              10:19 member‹size›
+                10:14 identifier‹name›
+              10:31 member‹size›
+                10:26 identifier‹name›
+            10:39 identifier‹age›

--- a/js/tests/t180_astLineNumbers_test.grace
+++ b/js/tests/t180_astLineNumbers_test.grace
@@ -1,0 +1,27 @@
+import "lexer" as lexer
+import "parser" as parser
+import "ast" as ast
+import "util" as util
+
+def input = list.with(
+    "type Person = type \{",
+    "  age -> Number",
+    "  name -> String",
+    "\}",
+    "",
+    "class person.new(name', age') \{",
+    "  def name is public = name'",
+    "  def age is public = age'",
+    "  method getShoeSize \{",
+    "    return ((name.size * name.size) + age)",
+    "  }",
+    "}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+for (nodes) do { n->
+    print(n.pretty(0))
+}

--- a/tests/t180_astLineNumbers.out
+++ b/tests/t180_astLineNumbers.out
@@ -1,0 +1,53 @@
+1:1 typedec
+  1:6 identifierBinding‹Person›
+  Value:1:15 typeliteral
+      Types:
+      Methods:
+        2:3 methodtype
+          Name: age
+          Returns:
+            2:10 identifier‹Number›
+          Signature:
+            2:7 signaturepart: age
+              Parameters:
+        3:3 methodtype
+          Name: name
+          Returns:
+            3:11 identifier‹String›
+          Signature:
+            3:8 signaturepart: name
+              Parameters:
+
+
+5:0 blank
+6:2 class
+  Name: 6:7 identifierBinding‹person›
+  Factory method: 6:14 identifierBinding‹new›
+  Signature:
+    Part: new
+      Parameters:
+        6:18 identifierBinding‹name'›
+        6:25 identifierBinding‹age'›
+  Body:
+    7:3 defdec
+      7:7 identifierBinding‹name›
+      Value: 7:24 identifier‹name'›
+      Annotations: 7:15 identifier‹public›
+    8:3 defdec
+      8:7 identifierBinding‹age›
+      Value: 8:23 identifier‹age'›
+      Annotations: 8:14 identifier‹public›
+    9:1 method
+      Name: 9:10 identifierBinding‹getShoeSize›
+      Signature:
+        Part: getShoeSize
+          Parameters:
+      Body:
+        10:5 return
+          10:19 op‹+›
+            10:19 op‹*›
+              10:19 member‹size›
+                10:14 identifier‹name›
+              10:31 member‹size›
+                10:26 identifier‹name›
+            10:39 identifier‹age›

--- a/tests/t180_astLineNumbers_test.grace
+++ b/tests/t180_astLineNumbers_test.grace
@@ -1,0 +1,27 @@
+import "lexer" as lexer
+import "parser" as parser
+import "ast" as ast
+import "util" as util
+
+def input = list.with(
+    "type Person = type \{",
+    "  age -> Number",
+    "  name -> String",
+    "\}",
+    "",
+    "class person.new(name', age') \{",
+    "  def name is public = name'",
+    "  def age is public = age'",
+    "  method getShoeSize \{",
+    "    return ((name.size * name.size) + age)",
+    "  }",
+    "}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+for (nodes) do { n->
+    print(n.pretty(0))
+}


### PR DESCRIPTION
This pull request solves the problem of incorrect line numbers in the parse tree/AST (issue #104) and also includes documentation for the changes I made to GCT files (to preserve line numbers for type-checking against imported types).