### PR TITLE
Include comment nodes in AST

### DIFF
--- a/js/tests/t181_astComments.out
+++ b/js/tests/t181_astComments.out
@@ -1,0 +1,31 @@
+comments for node 1:
+  1:1 comment(Comment def A)
+comments for node 2:
+comments for node 3:
+  3:1 comment(Comment var 1A)
+  5:1 comment(Comment var 1B)
+comments for node 4:
+comments for node 5:
+  8:1 comment(Comment var 2A)
+comments for node 6:
+comments for node 7:
+  10:1 comment(Comment type A)
+  11:1 comment(Comment type B)
+  13:1 comment(Comment type C)
+  inner comments:
+    15:5 comment(Comment for methodtype 1A)
+    16:20 comment(Comment for methodtype 1B)
+
+    17:5 comment(Comment for methodtype 2A)
+    18:5 comment(Comment for methodtype 2B)
+
+comments for node 8:
+comments for node 9:
+  21:1 comment(Comment method A)
+  22:20 comment(Comment method B)
+  23:5 comment(Comment method C)
+  24:5 comment(Comment method D)
+comments for node 10:
+comments for node 11:
+  29:1 comment(Comment class A)
+  30:1 comment(Comment class B)

--- a/js/tests/t181_astComments_test.grace
+++ b/js/tests/t181_astComments_test.grace
@@ -1,0 +1,61 @@
+import "lexer" as lexer
+import "parser" as parser
+import "ast" as ast
+import "util" as util
+
+def input = list.with(
+    "//Comment def A",
+    "def x = 10",
+    "//Comment var 1A",
+    "var y := 47",
+    "//Comment var 1B",
+    "",
+    "var z := 42",
+    "//Comment var 2A",
+    "",
+    "//Comment type A",
+    "//Comment type B",
+    "type Person = \{",
+    "//Comment type C",
+    "",
+    "    //Comment for methodtype 1A",
+    "    name -> String //Comment for methodtype 1B",
+    "    //Comment for methodtype 2A",
+    "    //Comment for methodtype 2B",
+    "    age -> Number",
+    "}",
+    "//Comment method A",
+    "method m -> Done \{ //Comment method B",
+    "    //Comment method C",
+    "    //Comment method D",
+    "    print \"hello\"",
+    "    //Comment method E (should not print)",
+    "\}",
+    "",
+    "//Comment class A",
+    "//Comment class B",
+    "class person.new(name', age') -> Person \{",
+    "   def name:String is public = name'",
+    "   def age:Number is public = age'",
+    "\}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+for (1..nodes.size) do { i ->
+    print "comments for node {i}:"
+    for (nodes[i].comments) do { c ->
+        print ("  "++c.pretty(0))
+    }
+    if (nodes[i].kind == "typedec") then {
+        print "  inner comments:"
+        for (nodes[i].value.methods) do {mt ->
+            for (mt.comments) do { mtc ->
+                print ("    "++mtc.pretty(0))
+            }
+            print ""
+        }
+    }
+}

--- a/tests/t181_astComments.out
+++ b/tests/t181_astComments.out
@@ -1,0 +1,31 @@
+comments for node 1:
+  1:1 comment(Comment def A)
+comments for node 2:
+comments for node 3:
+  3:1 comment(Comment var 1A)
+  5:1 comment(Comment var 1B)
+comments for node 4:
+comments for node 5:
+  8:1 comment(Comment var 2A)
+comments for node 6:
+comments for node 7:
+  10:1 comment(Comment type A)
+  11:1 comment(Comment type B)
+  13:1 comment(Comment type C)
+  inner comments:
+    15:5 comment(Comment for methodtype 1A)
+    16:20 comment(Comment for methodtype 1B)
+
+    17:5 comment(Comment for methodtype 2A)
+    18:5 comment(Comment for methodtype 2B)
+
+comments for node 8:
+comments for node 9:
+  21:1 comment(Comment method A)
+  22:20 comment(Comment method B)
+  23:5 comment(Comment method C)
+  24:5 comment(Comment method D)
+comments for node 10:
+comments for node 11:
+  29:1 comment(Comment class A)
+  30:1 comment(Comment class B)

--- a/tests/t181_astComments_test.grace
+++ b/tests/t181_astComments_test.grace
@@ -1,0 +1,61 @@
+import "lexer" as lexer
+import "parser" as parser
+import "ast" as ast
+import "util" as util
+
+def input = list.with(
+    "//Comment def A",
+    "def x = 10",
+    "//Comment var 1A",
+    "var y := 47",
+    "//Comment var 1B",
+    "",
+    "var z := 42",
+    "//Comment var 2A",
+    "",
+    "//Comment type A",
+    "//Comment type B",
+    "type Person = \{",
+    "//Comment type C",
+    "",
+    "    //Comment for methodtype 1A",
+    "    name -> String //Comment for methodtype 1B",
+    "    //Comment for methodtype 2A",
+    "    //Comment for methodtype 2B",
+    "    age -> Number",
+    "}",
+    "//Comment method A",
+    "method m -> Done \{ //Comment method B",
+    "    //Comment method C",
+    "    //Comment method D",
+    "    print \"hello\"",
+    "    //Comment method E (should not print)",
+    "\}",
+    "",
+    "//Comment class A",
+    "//Comment class B",
+    "class person.new(name', age') -> Person \{",
+    "   def name:String is public = name'",
+    "   def age:Number is public = age'",
+    "\}"
+)
+
+util.lines := input
+def tokens = lexer.new.lexinput(input)
+def nodes = parser.parse(tokens)
+
+for (1..nodes.size) do { i ->
+    print "comments for node {i}:"
+    for (nodes[i].comments) do { c ->
+        print ("  "++c.pretty(0))
+    }
+    if (nodes[i].kind == "typedec") then {
+        print "  inner comments:"
+        for (nodes[i].value.methods) do {mt ->
+            for (mt.comments) do { mtc ->
+                print ("    "++mtc.pretty(0))
+            }
+            print ""
+        }
+    }
+}


### PR DESCRIPTION
With these changes, the parser no longer ignores comments. It
creates commentNodes out of them and then, if the comments are
surrounding a vardec, defdec, methoddec, typedec, class definition,
or methodtype, the comments are attached as children of that
corresponding node. If they aren't surrounding one of these nodes,
they are discarded and not attached anywhere in the AST. These
changes are necessary for GraceDoc, the Grace documentation
generator.