### PR TITLE
Fixes undeclared NoSuchMethod in gracelib.js

### DIFF
--- a/js/gracelib.js
+++ b/js/gracelib.js
@@ -2456,7 +2456,7 @@ GraceMirror.prototype = {
             var exceptionMsg = new GraceString("no method " + name + " in mirror for ");
             var objDescription = callmethod(this.subject, "asString", [0]);
             exceptionMsg = callmethod(exceptionMsg, "++", [1], objDescription);
-            throw new GraceExceptionPacket(NoSuchMethod, exceptionMsg);
+            throw new GraceExceptionPacket(NoSuchMethodErrorObject, exceptionMsg);
         }
     },
     className: 'objectMirror'


### PR DESCRIPTION
Should have been NoSuchMethodErrorObject.