### PR TITLE
Automatically includes libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ echo:
 expWeb: expWebDeploy
 
 expWebBuild: js grace-web-editor/scripts/setup.js $(filter-out js/tabs.js,$(filter %.js,$(WEBFILES))) $(ALL_LIBRARY_MODULES:%.grace=js/%.js)
+	./includeJSLibraries $(ALL_LIBRARY_MODULES:%.grace=js/%.js)
 	[ -d grace-web-editor/js ] || mkdir -m 755 grace-web-editor/js
 	ln -f $(filter-out js/samples.js js/tabs.js,$(filter %.js,$(WEBFILES))) grace-web-editor/js
 	ln -f $(GRAPHIX:%.grace=js/%.js) grace-web-editor/js

--- a/includeJSLibraries
+++ b/includeJSLibraries
@@ -1,0 +1,11 @@
+#!/bin/bash 
+
+for i in $*; do 
+    if [[ $i =~ .*\.js$ ]] && 
+       [ $i != "js/tabs.js" ]; then
+        BACKGROUND=${BACKGROUND}"  window.importScripts(\"../$i\");\n"
+        INDEX=${INDEX}"    <script src=\"$i\" type=\"text/javascript\"></script>\n"
+    fi
+done
+cat grace-web-editor/scripts/background.in.js | sed -e 's|JAVASCRIPT_SRC_FILES|'"$BACKGROUND"'|' >grace-web-editor/scripts/background.js
+cat grace-web-editor/index.in.html | sed -e 's|JAVASCRIPT_SRC_FILES|'"$INDEX"'|' >grace-web-editor/index.html


### PR DESCRIPTION
Rebased and rebuilt, with a much cleaner history this time.

Requires grace-web-editor to contain a background.in.js file and an
index.in.html file.  To build, simply run `make expWebBuild`