### PR TITLE
Port to OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ l1/collectionsPrelude%gct l1/collectionsPrelude%gcn: collectionsPrelude.grace $(
 	$(KG)/minigrace $(VERBOSITY) --make --noexec --dir l1 $<
 
 l1/curl.gso: curl.c gracelib.h
-	gcc -g -std=c99 $(UNICODE_LDFLAGS) -o $@ -shared -fPIC curl.c -lcurl
+	gcc -g -std=c99 $(UNICODE_LDFLAGS) -I/usr/local/include -L/usr/local/lib -o $@ -shared -fPIC curl.c -lcurl
 
 l1/mirrors.gso: $(KG)/mirrors.gso
 	cd l1 && ln -f ../$(KG)/mirrors.gso .

--- a/c/environ-Darwin
+++ b/c/environ-Darwin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" ]
 then

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export unset CDPATH
 DISTRIB=tree

--- a/includeJSLibraries
+++ b/includeJSLibraries
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for i in $*; do
     if [[ $i =~ .*\.js$ ]] &&

--- a/js/sample/dialects/requireTypes.grace
+++ b/js/sample/dialects/requireTypes.grace
@@ -1,1 +1,0 @@
-../../../sample/dialects/requireTypes.grace

--- a/js/tests/harness
+++ b/js/tests/harness
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 absolutePath(){
     [[ -d $1 ]] && { cd "$1"; echo "$(pwd -P)"; } ||

--- a/known-good/make-known-good
+++ b/known-good/make-known-good
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 COMMIT=$1

--- a/minigrace-js
+++ b/minigrace-js
@@ -1,4 +1,4 @@
-#! /bin/bash -f
+#! /usr/bin/env bash -f
 
 absolutePath(){
     [[ -d $1 ]] && { cd "$1"; echo "$(pwd -P)"; } ||

--- a/modules/tests/harness_js
+++ b/modules/tests/harness_js
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 absolutePath(){
     [[ -d $1 ]] && { cd "$1"; echo "$(pwd -P)"; } ||

--- a/tests/harness
+++ b/tests/harness
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 absolutePath(){
     [[ -d $1 ]] && { cd "$1"; echo "$(pwd -P)"; } ||

--- a/tools/calculate-version
+++ b/tools/calculate-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(git rev-parse --show-toplevel)"
 

--- a/tools/check-buildinfo
+++ b/tools/check-buildinfo
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 PREFIX=$1
 INCLUDE_PATH=$2

--- a/tools/check-l1-buildinfo
+++ b/tools/check-l1-buildinfo
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 PREFIX=$1
 INCLUDE_PATH=$2

--- a/tools/emptyCollections
+++ b/tools/emptyCollections
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 for f in "$@"
 do
     sed -e "s/list\.empty/emptyList/g" -e "s/sequence\.empty/emptySequence/g" -e "s/set\.empty/emptySet/g" -e "s/dictionary.empty/emptyDictionary/g" $f > $f.$$ && mv $f.$$ $f

--- a/tools/generations.dat
+++ b/tools/generations.dat
@@ -1,4 +1,4 @@
-#!/bin/bash -c false
+#!/usr/bin/env bash -c false
 
 # Data file containing generation numbers of some versions to simplify
 # calculation and avoid hitting recursion limits.

--- a/tools/git-authors
+++ b/tools/git-authors
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 if [ -e .git ]
 then
     git log --format='%aN' | \

--- a/tools/git-calculate-generation
+++ b/tools/git-calculate-generation
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 if [ ${BASH_VERSINFO[0]} -ge 4 ]

--- a/tools/make-depend
+++ b/tools/make-depend
@@ -1,4 +1,4 @@
-#! /bin/bash -f
+#! /usr/bin/env bash -f
 
 Dependents=$(awk 'BEGIN { ORS = " " }
     /^import / { print substr($2, 2, length($2)-2)

--- a/tools/set-difference
+++ b/tools/set-difference
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # computes $1 \ $2
 # each parameter must be a list of words, separated by spaces

--- a/tools/set-up-generations
+++ b/tools/set-up-generations
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -e ".git-generation-cache" ]
 then

--- a/tools/tarball-bootstrap
+++ b/tools/tarball-bootstrap
@@ -55,7 +55,7 @@ then
     exit 0
 fi
 
-tar xf "$TARBALL" || die "Failed to extract tarball"
+bunzip2 -c - $TARBALL | tar xf - || die "Failed to extract tarball"
 dir=$(sed 's/.tar.bz2//' < <(basename "$TARBALL"))
 pushd "$dir"
 ./configure || die "Failed to configure tarball"

--- a/tools/tarball-bootstrap
+++ b/tools/tarball-bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Use a tarball to provide known-good for bootstrapping
 
 die() {
@@ -58,7 +58,7 @@ fi
 bunzip2 -c - $TARBALL | tar xf - || die "Failed to extract tarball"
 dir=$(sed 's/.tar.bz2//' < <(basename "$TARBALL"))
 pushd "$dir"
-./configure || die "Failed to configure tarball"
+/usr/bin/env bash ./configure || die "Failed to configure tarball"
 make || die "Failed to build"
 hash=$(./minigrace --version | awk '/git revision/ { print $3 }')
 kgdir=../known-good/$(uname -s)-$(uname -m)/$hash

--- a/tools/validate-commit-message
+++ b/tools/validate-commit-message
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Enforce that the commit message is correctly formatted.
 # It must:

--- a/tools/warnAbout
+++ b/tools/warnAbout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PATH_VAR_NAME=$1
 INSTALL_PATH=$2
 if [[ `printenv ${PATH_VAR_NAME}` != *${INSTALL_PATH}* ]]


### PR DESCRIPTION
This is a fairly minimalistic port to OpenBSD. It removes some obviously too-Linux Linuxisms, which will probably make things compile better on other platforms (I have tested that it still builds on Linux, but you might want to double-check OS X before merging). Because the minigrace GC is highly recursive, I had to increase the stack size in order to avoid segfaults, but with that change, things seem to work.

However, both my PR and the main master branch die at this point in the build:

```
GRACE_MODULE_PATH=js:modules ./minigrace --target js --dir js --make  modules/objectdraw.grace
objectdraw.grace[31:(15)]: Syntax error: a type declaration must have an '=' after the type name.
  30: // and returning a value of type R
  31: type Function<T, R> = prelude.Fun<T,R>
--------------------^

Did you mean:
  31: type Function=
No method '_apply(1)'; available methods are:
  apply  apply(1)  apply(2)  apply(3)  apply(4)  apply(5)  apply(6)  apply(7)
  apply(8)  apply(9)  applyIndirectly(1)  match(1)  asString  asDebugString  ::(1)
  isMe(1)  ≠(1)  pattern(1)  _apply
NoSuchMethod at line 1918 of collectionsPrelude: no method '_apply(1)' in Block[errormessages:264].
  called from Block[errormessages:264]._apply(1) (defined nowhere) at collectionsPrelude:1918
  called from Block[errormessages:264].apply(1) (defined at unknown:0) at collectionsPrelude:1918
  called from Block[collectionsPrelude:1917]._apply (defined at collectionsPrelude:1963) at collectionsPrelude:1917
  called from Block[collectionsPrelude:1917].apply (defined at unknown:0) at collectionsPrelude:1917
  called from StandardPrelude.while(1)do(1) (defined at unknown:0 in StandardPrelude module) at collectionsPrelude:1917
  called from range.object.do(1) (defined at collectionsPrelude:1915 in range.object created at collectionsPrelude:1874) at collectionsPrelude:1881
  called from StandardPrelude.for(1)do(1) (defined at unknown:0 in StandardPrelude module) at collectionsPrelude:1881
  called from Block[errormessages:261]._apply(1) (defined at errormessages:441) at collectionsPrelude:1918
  called from Block[errormessages:261].apply(1) (defined at unknown:0) at collectionsPrelude:1918
  called from Block[collectionsPrelude:1917]._apply (defined at collectionsPrelude:1963) at collectionsPrelude:1919
  called from Block[collectionsPrelude:1917].apply (defined at unknown:0) at collectionsPrelude:1919
  called from StandardPrelude.while(1)do(1) (defined at unknown:0 in StandardPrelude module) at collectionsPrelude:1917
  called from range.object.do(1) (defined at collectionsPrelude:1915 in range.object created at collectionsPrelude:1874) at collectionsPrelude:1881
  called from StandardPrelude.for(1)do(1) (defined at unknown:0 in StandardPrelude module) at collectionsPrelude:1881
  called from suggestion.new.print (defined at errormessages:260 in suggestion.new created at errormessages:14) at util:316
  called from Block[util:314]._apply(1) (defined at util:535) at util:314
  called from Block[util:314].apply(1) (defined at unknown:0) at util:314
  called from builtinList.do(1) (defined at unknown:0) at util:314
  called from StandardPrelude.for(1)do(1) (defined at unknown:0 in StandardPrelude module) at util:314
  called from Module<util>.generalError(6) (defined at util:301 in util module) at util:288
  called from Module<util>.syntaxError(6) (defined at util:278 in util module) at errormessages:393
  called from Module<errormessages>.syntaxError(1)atPosition(2)withSuggestions(1) (defined at errormessages:387 in errormessages module) at errormessages:384
  called from Module<errormessages>.syntaxError(1)atPosition(2)withSuggestion(1) (defined at errormessages:383 in errormessages module) at parser:3029
  called from Module<parser>.typedec (defined at parser:3003 in parser module) at parser:3117
  called from Module<parser>.statement (defined at parser:3096 in parser module) at parser:3388
  called from Block[parser:3370]._apply (defined at parser:3403) at lexer:1101
  called from Block[parser:3370].apply (defined at unknown:0) at lexer:1101
  called from StandardPrelude.while(1)do(1) (defined at unknown:0 in StandardPrelude module) at parser:3370
  called from Module<parser>.parse(1) (defined at parser:3350 in parser module) at minigrace:33
    1917:                 while {val <= stop} do {
    1918:                     block1.apply(val)
    1919:                     val := val + 1
Makefile:365: recipe for target 'js/objectdraw.js' failed
```

I don't know why, and I haven't tried to fix it. This PR at least doesn't make this worse though.