### PR TITLE
Adds "createCanvas" method

### DIFF
--- a/js/sample/graphics/logo.grace
+++ b/js/sample/graphics/logo.grace
@@ -3,7 +3,8 @@
 // using only statements of what should happen. The turtle module
 // handles the actual drawing and user interface.
 import "turtle" as turtle
-inherit prelude.methods
+inherits prelude
+type Point = prelude.Point
 
 def red is public = turtle.red
 def green is public = turtle.green
@@ -32,6 +33,12 @@ method speed:=(sp) {
     if (sp >= 1) then {
         turtle.speed := sp.floor
     }
+}
+
+//Method to create a pop-up canvas
+method createCanvas(size:Point)
+{
+     turtle.useCanvas(size)
 }
 
 def thisDialect is public = object {

--- a/js/sample/graphics/logo.grace
+++ b/js/sample/graphics/logo.grace
@@ -3,7 +3,7 @@
 // using only statements of what should happen. The turtle module
 // handles the actual drawing and user interface.
 import "turtle" as turtle
-inherits prelude
+inherit prelude.methods
 type Point = prelude.Point
 
 def red is public = turtle.red


### PR DESCRIPTION
This commit adds a createCanvas(size:Point) method to the "Logo" dialect
and the relevant supporting functions to "Turtle." This method creates
a pop-up canvas and allows the user to set the canvas size. This commit
also adds some error-checking code that will automatically switch to a
pop-up window canvas if the built-in canvas is not found.