### PR TITLE
Allow expressions in type-arguments

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -1043,61 +1043,7 @@ method prefixop {
 
 method generic {
     if (sym.isLGeneric) then {
-        def id = values.pop
-        def gens = list [ ]
-        def startToken = sym
-        next
-        while {sym.isIdentifier} do {
-            identifier
-            while {sym.isDot} do {
-                next
-                def receiver = values.pop
-                if (sym.kind != "identifier") then {
-                    def suggestions = list [ ]
-                    var suggestion := errormessages.suggestion.new
-                    suggestion.insert("«type name»")afterToken(lastToken)
-                    suggestions.push(suggestion)
-                    suggestion := errormessages.suggestion.new
-                    suggestion.deleteToken(lastToken)
-                    suggestions.push(suggestion)
-                    errormessages.syntaxError("a type name must follow the '.'.")atPosition(
-                        lastToken.line, lastToken.linePos + 1)withSuggestions(suggestions)
-                }
-                identifier
-                def attributeName = values.pop
-                def memberNd = ast.memberNode.new(attributeName.value, receiver).
-                      setPositionFrom(receiver)
-                values.push(memberNd)
-            }
-            generic
-            gens.push(values.pop)
-            if (sym.isComma) then {
-                next
-            } else {
-                if (sym.kind != "rgeneric") then {
-                    def suggestion = errormessages.suggestion.new
-                    suggestion.insert "⟧" afterToken(lastToken)
-                    def suggestion2 = errormessages.suggestion.new
-                    suggestion2.insert " " beforeToken(startToken)
-                    def suggestions = [suggestion, suggestion2]
-                    errormessages.syntaxError("a type containing a '⟦' must end with a '⟧'.")
-                          atPosition(lastToken.line, lastToken.linePos + lastToken.size)
-                          withSuggestions(suggestions)
-                }
-            }
-        }
-        if (sym.kind != "rgeneric") then {
-            def suggestion = errormessages.suggestion.new
-            suggestion.insert "⟧" afterToken(lastToken)
-            def suggestion2 = errormessages.suggestion.new
-            suggestion2.insert " " beforeToken(startToken)
-            def suggestions = [suggestion, suggestion2]
-            errormessages.syntaxError("a type containing a '⟦' must end with a '⟧'.")
-                  atPosition(lastToken.line, lastToken.linePos + lastToken.size)
-                  withSuggestions(suggestions)
-        }
-        next
-        values.push(ast.genericNode.new(id, gens))
+        values.push(ast.genericNode.new(values.pop, typeArgs))
     }
 }
 method trycatch {
@@ -1883,7 +1829,7 @@ method typeArgs {
     def args = list [ ]
     def startToken = sym
     next
-    while {successfulParse{typeArg}} do {
+    while {successfulParse{typeexpression}} do {
         args.add(values.pop)
         if (sym.isComma) then { next }
     }
@@ -1893,23 +1839,18 @@ method typeArgs {
         def suggestion2 = errormessages.suggestion.new
         suggestion2.insert " " beforeToken(startToken)
         def suggestions = [suggestion, suggestion2]
-        errormessages.syntaxError "a method request containing a '⟦' must have a matching '⟧'. "
+        errormessages.syntaxError "a type argument list containing a '⟦' must have a matching '⟧'. "
               atPosition(lastToken.line, lastToken.linePos + lastToken.size)
               withSuggestions(suggestions)
     }
+    if (args.isEmpty) then {
+        def suggestion = errormessages.suggestion.new
+        suggestion.insert("«type expression»")afterToken(lastToken)
+        errormessages.syntaxError "a type argument list cannot be empty. "
+            atPosition(lastToken.line, lastToken.linePos + lastToken.size) withSuggestion(suggestion)
+    }
     next
     return args
-}
-
-method typeArg {
-    // Parses a single type argument, and leaves it on the values stack.
-
-    // Special case for interface Literals without leading 'interface' keyword.
-    if (sym.isLBrace) then {
-        interfaceLiteral
-    } else {
-        expression(noBlocks)
-    }
 }
 
 method errorDefNoName {

--- a/parser.grace
+++ b/parser.grace
@@ -1846,7 +1846,7 @@ method typeArgs {
     if (args.isEmpty) then {
         def suggestion = errormessages.suggestion.new
         suggestion.insert("«type expression»")afterToken(lastToken)
-        errormessages.syntaxError "a type argument list cannot be empty. "
+        errormessages.syntaxError "a type argument list starting with a '⟦' must end with a matching '⟧'. "
             atPosition(lastToken.line, lastToken.linePos + lastToken.size) withSuggestion(suggestion)
     }
     next

--- a/parser.grace
+++ b/parser.grace
@@ -1903,16 +1903,12 @@ method typeArgs {
 
 method typeArg {
     // Parses a single type argument, and leaves it on the values stack.
-    // TODO: 'identifier' could be a dotted identifier, 
-    //        or perhaps a type expression?
 
-    if (sym.isIdentifier) then {
-        identifier
-        if (sym.isLGeneric) then {
-            values.push(ast.genericNode.new(values.pop, typeArgs))
-        }
-    } else {
+    // Special case for interface Literals without leading 'interface' keyword.
+    if (sym.isLBrace) then {
         interfaceLiteral
+    } else {
+        expression(noBlocks)
     }
 }
 


### PR DESCRIPTION
This is a fix for #41 and #242. However, it now has the bug of #289.
In particular, the following code prints "true" and "false":

```
method foo[[T]] { print(T.matches(3) && T.matches("3")) }
foo[[String|Number]]
foo[[1 + 2]]
```

Previously, both calls to `foo` were syntax errors.  However, according to the  [grammar],(https://github.com/gracelang/language/blob/master/languageSpec/graceGrammar.txt) only the second one should be.