### PR TITLE
Import first .js/.grace file found in GRACE_MODULE_PATH

### DIFF
--- a/xmodule.grace
+++ b/xmodule.grace
@@ -175,23 +175,23 @@ method checkimport(nm, pathname, isDialect, sourceRange) is confidential {
     def pnJs = filePath.fromString(pathname).setExtension "js"
     def pnGrace = pnJs.copy.setExtension "grace"
 
-    var moduleFileJs := util.files([pnJs, pnGrace]) on (util.outDir)
+    var moduleFile := util.firstFile[pnJs, pnGrace] on (util.outDir)
                                 orPath (gmp) otherwise { m ->
         def rm = errormessages.readableStringFrom(m)
         errormessages.error("I can't find {pnJs.shortName} " ++
             "or {pnGrace.shortName}; looked in {rm}.") atRange (sourceRange)
     }
-    if (moduleFileJs.extension == ".grace") then {
+    if (moduleFile.extension == ".grace") then {
         util.log 50 verbose "about to compile module \"{nm}\""
-        compileModule (nm) inFile (moduleFileJs.asString)
+        compileModule (nm) inFile (moduleFile.asString)
                 forDialect (isDialect) atRange (sourceRange)
-        moduleFileJs := util.file(pnJs) on(util.outDir) orPath (gmp) otherwise { m ->
+        moduleFile := util.file(pnJs) on(util.outDir) orPath (gmp) otherwise { m ->
             def rm = errormessages.readableStringFrom(m)
-            errormessages.error("I just compiled {moduleFileJs} " ++
+            errormessages.error("I just compiled {moduleFile} " ++
                 "but can't find the .js file; looked in {rm}.") atRange (sourceRange)
         }
     }
-    util.log 50 verbose "found module \"{nm}\" in {moduleFileJs}"
+    util.log 50 verbose "found module \"{nm}\" in {moduleFile}"
 
     def gctDict = parseGCT(nm)
     def sourceFile = filePath.fromString(gctDict.at "path" .first)
@@ -201,12 +201,12 @@ method checkimport(nm, pathname, isDialect, sourceRange) is confidential {
         sourceFile.exists
     }
     if ( util.target == "js" ) then {
-        if (moduleFileJs.exists && {
-            sourceExists.not || { moduleFileJs.newer(sourceFile) }
+        if (moduleFile.exists && {
+            sourceExists.not || { moduleFile.newer(sourceFile) }
         }) then {
         } else {
-            if (moduleFileJs.newer(sourceFile).not) then {
-                util.log 60 verbose "{moduleFileJs} not newer than {sourceFile}"
+            if (moduleFile.newer(sourceFile).not) then {
+                util.log 60 verbose "{moduleFile} not newer than {sourceFile}"
             }
             if (sourceFile.exists) then {
                 compileModule (nm) inFile (sourceFile.asString)
@@ -219,7 +219,7 @@ method checkimport(nm, pathname, isDialect, sourceRange) is confidential {
         }
         imports.other.add(nm)
     }
-    addTransitiveImports(moduleFileJs.directory, isDialect, nm, sourceRange)
+    addTransitiveImports(moduleFile.directory, isDialect, nm, sourceRange)
 }
 
 method addTransitiveImports(directory, isDialect, moduleName, sourceRange) is confidential {

--- a/xmodule.grace
+++ b/xmodule.grace
@@ -172,22 +172,22 @@ method checkimport(nm, pathname, isDialect, sourceRange) is confidential {
     }
     util.log 50 verbose "checking module \"{nm}\""
     def gmp = sys.environ.at "GRACE_MODULE_PATH"
-    def pn = filePath.fromString(pathname).setExtension "js"
-    def moduleFileJs = util.file(pn) on (util.outDir)
-                                orPath (gmp) otherwise { l ->
-        def graceFileName = pn.copy.setExtension "grace"
-        def moduleFileGrace = util.file(graceFileName) on(util.outDir)
+    def pnJs = filePath.fromString(pathname).setExtension "js"
+    def pnGrace = pnJs.copy.setExtension "grace"
+
+    var moduleFileJs := util.files([pnJs, pnGrace]) on (util.outDir)
                                 orPath (gmp) otherwise { m ->
-            def rm = errormessages.readableStringFrom(m)
-            errormessages.error("I can't find {pn.shortName} " ++
-                "or {graceFileName.shortName}; looked in {rm}.") atRange (sourceRange)
-        }
+        def rm = errormessages.readableStringFrom(m)
+        errormessages.error("I can't find {pnJs.shortName} " ++
+            "or {pnGrace.shortName}; looked in {rm}.") atRange (sourceRange)
+    }
+    if (moduleFileJs.extension == ".grace") then {
         util.log 50 verbose "about to compile module \"{nm}\""
-        compileModule (nm) inFile (moduleFileGrace.asString)
+        compileModule (nm) inFile (moduleFileJs.asString)
                 forDialect (isDialect) atRange (sourceRange)
-        util.file(pn) on(util.outDir) orPath (gmp) otherwise { m ->
+        moduleFileJs := util.file(pnJs) on(util.outDir) orPath (gmp) otherwise { m ->
             def rm = errormessages.readableStringFrom(m)
-            errormessages.error("I just compiled {moduleFileGrace} " ++
+            errormessages.error("I just compiled {moduleFileJs} " ++
                 "but can't find the .js file; looked in {rm}.") atRange (sourceRange)
         }
     }


### PR DESCRIPTION
This makes it so that when importing, the first `.js` or `.grace` file found in `GRACE_MODULE_PATH` will be used. ~~Previousesly~~, Previously, it would only load a `.grace` file if no `.js` file was found in `GRACE_MODULE_PATH` .

E.g., if `GRACE_MODULE_PATH` is `./foo:./bar`, whith the following directory structure:
```
├── foo
│   ├── mod.grace
├── bar
│   ├── mod.js
```

An `import "mod"` statement will now import `foo/mod.grace`, previousesly it would import `bar/mod.js`.

This fixes issue #293