### PR TITLE
Add type declarations to GCT and parameterize methodInInterface

### DIFF
--- a/js/tests/t179_gctTypeInformation.out
+++ b/js/tests/t179_gctTypeInformation.out
@@ -34,6 +34,8 @@ public:
  m(1)
  x:=(1)
  xx
+publicMethod:m(1):
+ m(y:Number) → Done
 publicMethod:x:=(1):
  x:=(x': Number) → Done
 publicMethod:xx:
@@ -42,6 +44,19 @@ publicMethodTypes:
  m(y:Number) → Done
  x:=(x': Number) → Done
  xx → Number
+typedec-of:A:
+ type A = B⟦T⟧ | other.C | other.U⟦T⟧ | interface {
+    m1(n:Number) → Number
+    m2(n:Number) → Done}
+typedec-of:D:
+ type D = Dictionary⟦K, T⟧ & F & G
+typedec-of:H⟦T⟧:
+ type H⟦T⟧ = interface {
+        m3(x:T) → T}
+typedec-of:Z:
+ type Z = interface {
+    m4(x:Y) → Y} & interface {
+    m5(x:Z) → Z}
 types:
  A
  D

--- a/parser.grace
+++ b/parser.grace
@@ -2777,6 +2777,14 @@ method doreturn {
     }
 }
 
+method methodInInterface(toks) {
+    tokens := toks
+    next
+    methodInInterface
+
+    values.pop
+}
+
 method methodInInterface {
     // parses a method signature in an interface literal, and pushes the
     // resulting node, along with any comments, onto values

--- a/xmodule.grace
+++ b/xmodule.grace
@@ -598,6 +598,7 @@ method buildGctFor(module) {
             if (v.isPublic) then {
                 meths.add(v.nameString)
                 publicMethodTypes.push(generateMethodHeader(v))
+                gct.at("publicMethod:{v.nameString}") put([generateMethodHeader(v)])
             } else {
                 confidentials.push(v.nameString)
             }
@@ -608,9 +609,11 @@ method buildGctFor(module) {
                 methodtypes := list [ ]
                 v.value.accept(typeVisitor)
                 gct.at "methodtypes-of:{v.nameWithParams}" put(methodtypes)
+                gct.at "typedec-of:{v.nameWithParams}" put([v.toGrace(0)])
             } else {
                 confidentials.push(v.nameString)
             }
+
         } elseif {v.kind == "defdec"} then {
             if (v.isPublic) then {
                 meths.add(v.nameString)


### PR DESCRIPTION
### Types in GCT

[We](https://github.com/pavlerohalj/staticTypes) have found that `methodtypes-of:` entry in GCT does not contain sufficient type information. We have added a `typedec-of:` entry that stores each type declaration in source Grace syntax. Getting a type declaration from such an entry is then straightforward:

```
def tokens = lex.lexLines(gct.at(key))
def typeDec = parser.typedec(tokens)
```

Moreover, `publicMethod` entry was not being added when a node encountered while building GCT was a method node.

### Parameterized methodInInterface

We use parameterized `methodInInterface` to process GCT keys that start with `publicMethod`. In particular: 

```
def tokens = lex.lexLines(gct.at(key))
def methodType = parser.methodInInterface(tokens)
``` 


