### PR TITLE
Fixed bug that prevents any fresh grace code from running

### DIFF
--- a/util.grace
+++ b/util.grace
@@ -420,7 +420,7 @@ method file(name) onPath(pathString) otherwise(action) {
         // might compile an imported file, but then be unable to find the
         // code that it just generated.
     if (locations.contains(execDir).not) then { locations.addLast(execDir) }
-    def candidate = filePath.fromString(name)
+    def candidate = name
     def originalDir = name.directory
     if (originalDir.first == "/") then {
         if (candidate.exists) then {


### PR DESCRIPTION
I was unable to run any grace code I created, even something as trivial as `touch empty.grace; mgc empty.grace` would cause a method not found error.

The problem line being `filePath.fromString(name)`, which makes no sense because `name` is already a `filePath` and not a string.

Suffice it to say, my commit has fixed the issue and I can no run grace code again!