### PR TITLE
Separate method types into individual GCT entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ JS-KG = js-kg/$(NPM_STABLE_VERSION)
 OBJECTDRAW = objectdraw.grace rtobjectdraw.grace stobjectdraw.grace animation.grace
 OBJECTDRAW_REAL = $(filter-out %tobjectdraw.grace, $(OBJECTDRAW))
 PRELUDESOURCEFILES = collections.grace standard.grace standardBundle.grace intrinsic.grace basicTypesBundle.grace pattern+typeBundle.grace equalityBundle.grace pointBundle.grace
-REALSOURCEFILES = ast.grace compiler.grace errormessages.grace fastDict.grace genjs.grace identifierKinds.grace identifierresolution.grace io.grace lexer.grace mirror.grace parser.grace prefixTree.grace regularExpression.grace shasum.grace sys.grace unicode.grace unixFilePath.grace util.grace xmodule.grace
+REALSOURCEFILES = ast.grace compiler.grace errormessages.grace mapDict.grace genjs.grace identifierKinds.grace identifierresolution.grace io.grace lexer.grace mirror.grace parser.grace prefixTree.grace regularExpression.grace shasum.grace sys.grace unicode.grace unixFilePath.grace util.grace xmodule.grace
 
 SOURCEFILES = $(REALSOURCEFILES) $(PRELUDESOURCEFILES)
 MGSOURCEFILES = buildinfo.grace $(SOURCEFILES)
 TYPE_DIALECTS = staticTypes requireTypes
-TEST_DEPENDENCIES = ast lexer fastDict collections parser xmodule errormessages standard identifierKinds
+TEST_DEPENDENCIES = ast lexer mapDict collections parser xmodule errormessages standard identifierKinds
 #   these are modules used in running the full test suite
 NPM_VERSION_PREFIX=1.0
 VERSION := $(NPM_VERSION_PREFIX).$(shell ./tools/git-calculate-generation)$(ALPHA-BETA)

--- a/Makefile.mgDependencies
+++ b/Makefile.mgDependencies
@@ -8,14 +8,15 @@ j1/errormessages.js: j1/util.js j1/standard.js
 j1/fastDict.js: j1/collections.js
 j1/genjs.js: j1/ast.js j1/util.js j1/unixFilePath.js j1/xmodule.js j1/errormessages.js j1/identifierKinds.js j1/identifierresolution.js j1/xmodule.js j1/standard.js j1/shasum.js j1/buildinfo.js
 j1/identifierKinds.js: j1/standard.js
-j1/identifierresolution.js: j1/standard.js j1/io.js j1/sys.js j1/ast.js j1/util.js j1/xmodule.js j1/fastDict.js j1/errormessages.js j1/identifierKinds.js j1/mirror.js j1/prefixTree.js
+j1/identifierresolution.js: j1/standard.js j1/io.js j1/sys.js j1/ast.js j1/util.js j1/xmodule.js j1/mapDict.js j1/errormessages.js j1/identifierKinds.js j1/mirror.js j1/prefixTree.js
 j1/io.js: j1/standard.js
-j1/lexer.js: j1/util.js j1/unicode.js  j1/fastDict.js j1/errormessages.js j1/standard.js j1/regularExpression.js
+j1/lexer.js: j1/util.js j1/unicode.js  j1/mapDict.js j1/errormessages.js j1/standard.js j1/regularExpression.js
+j1/mapDict.js: j1/collections.js
 j1/mirror.js: j1/intrinsic.js
 j1/parser.js: j1/io.js  j1/util.js j1/ast.js j1/errormessages.js j1/standard.js
 j1/pattern+typeBundle.js: j1/collections.js j1/equalityBundle.js j1/intrinsic.js j1/mirror.js
 j1/pointBundle.js: j1/intrinsic.js j1/basicTypesBundle.js j1/equalityBundle.js
-j1/prefixTree.js: j1/standard.js j1/fastDict.js
+j1/prefixTree.js: j1/standard.js j1/mapDict.js
 j1/regularExpression.js: j1/standard.js
 j1/shasum.js: j1/standard.js
 j1/standard.js: j1/standardBundle.js
@@ -25,7 +26,7 @@ j1/timer.js: j1/standard.js
 j1/typeComparison.js: j1/mirror.js j1/standard.js
 j1/unicode.js: j1/standard.js
 j1/unixFilePath.js: j1/standard.js j1/io.js
-j1/util.js: j1/io.js j1/sys.js j1/unixFilePath.js j1/standard.js j1/fastDict.js
+j1/util.js: j1/io.js j1/sys.js j1/unixFilePath.js j1/standard.js j1/mapDict.js
 j1/xmodule.js: j1/io.js j1/sys.js j1/util.js j1/ast.js j1/mirror.js j1/errormessages.js j1/unixFilePath.js j1/standard.js j1/shasum.js j1/regularExpression.js j1/buildinfo.js
 
 j2/ast.js: j2/util.js j2/util.js j2/identifierKinds.js j2/standard.js
@@ -35,17 +36,18 @@ j2/collections.js: j2/intrinsic.js
 j2/compiler.js: j2/util.js j2/genjs.js j2/lexer.js j2/parser.js j2/identifierresolution.js j2/buildinfo.js j2/standard.js j2/typeComparison.js
 j2/equalityBundle.js: j2/basicTypesBundle.js j2/intrinsic.js
 j2/errormessages.js: j2/util.js j2/standard.js
-j2/fastDict.js: j2/collections.js
+j2/mapDict.js: j2/collections.js
 j2/genjs.js: j2/ast.js j2/util.js j2/unixFilePath.js j2/xmodule.js j2/errormessages.js j2/identifierKinds.js j2/identifierresolution.js j2/xmodule.js j2/standard.js j2/buildinfo.js
 j2/identifierKinds.js: j2/standard.js j2/shasum.js
-j2/identifierresolution.js: j2/standard.js j2/io.js j2/sys.js j2/ast.js j2/util.js j2/xmodule.js j2/fastDict.js j2/errormessages.js j2/identifierKinds.js j2/mirror.js j2/prefixTree.js
+j2/identifierresolution.js: j2/standard.js j2/io.js j2/sys.js j2/ast.js j2/util.js j2/xmodule.js j2/mapDict.js j2/errormessages.js j2/identifierKinds.js j2/mirror.js j2/prefixTree.js
 j2/io.js: j2/standard.js
-j2/lexer.js: j2/util.js j2/unicode.js  j2/fastDict.js j2/errormessages.js j2/standard.js j2/regularExpression.js
+j2/lexer.js: j2/util.js j2/unicode.js  j2/mapDict.js j2/errormessages.js j2/standard.js j2/regularExpression.js
+j2/mapDict.js: j2/collections.js
 j2/mirror.js: j2/intrinsic.js
 j2/parser.js: j2/io.js  j2/util.js j2/ast.js j2/errormessages.js j2/standard.js
 j2/pattern+typeBundle.js: j2/collections.js j2/equalityBundle.js j2/intrinsic.js j2/mirror.js
 j2/pointBundle.js: j2/intrinsic.js j2/basicTypesBundle.js j2/equalityBundle.js
-j2/prefixTree.js: j2/standard.js j2/fastDict.js
+j2/prefixTree.js: j2/standard.js j2/mapDict.js
 j2/regularExpression.js: j2/standard.js
 j2/requireTypes.js: j2/dialect.js j2/standard.js
 j2/shasum.js: j2/standard.js
@@ -56,7 +58,7 @@ j2/timer.js: j2/standard.js
 j2/typeComparison.js: j2/mirror.js j2/standard.js
 j2/unicode.js: j2/standard.js
 j2/unixFilePath.js: j2/standard.js j2/io.js
-j2/util.js: j2/io.js j2/sys.js j2/unixFilePath.js j2/standard.js j2/fastDict.js
+j2/util.js: j2/io.js j2/sys.js j2/unixFilePath.js j2/standard.js j2/mapDict.js
 j2/xmodule.js: j2/io.js j2/sys.js j2/util.js j2/ast.js j2/mirror.js j2/errormessages.js j2/unixFilePath.js j2/standard.js j2/shasum.js j2/regularExpression.js j2/buildinfo.js
 
 j2/animation.js: j2/standard.js j2/timer.js

--- a/Makefile.mgDependencies
+++ b/Makefile.mgDependencies
@@ -1,7 +1,7 @@
 j1/ast.js: j1/util.js j1/util.js j1/identifierKinds.js j1/standard.js
 j1/basicTypesBundle.js: j1/intrinsic.js
 j1/buildinfo.js: j1/standard.js
-j1/collections.js: j1/intrinsic.js
+j1/collections.js: j1/basicTypesBundle.js j1/equalityBundle.js j1/intrinsic.js
 j1/compiler.js: j1/util.js j1/genjs.js j1/lexer.js j1/parser.js j1/identifierresolution.js j1/buildinfo.js j1/standard.js j1/typeComparison.js
 j1/equalityBundle.js: j1/basicTypesBundle.js j1/intrinsic.js
 j1/errormessages.js: j1/util.js j1/standard.js
@@ -32,7 +32,7 @@ j1/xmodule.js: j1/io.js j1/sys.js j1/util.js j1/ast.js j1/mirror.js j1/errormess
 j2/ast.js: j2/util.js j2/util.js j2/identifierKinds.js j2/standard.js
 j2/basicTypesBundle.js: j2/intrinsic.js
 j2/buildinfo.js: j2/standard.js
-j2/collections.js: j2/intrinsic.js
+j2/collections.js: j2/basicTypesBundle.js j2/equalityBundle.js j2/intrinsic.js
 j2/compiler.js: j2/util.js j2/genjs.js j2/lexer.js j2/parser.js j2/identifierresolution.js j2/buildinfo.js j2/standard.js j2/typeComparison.js
 j2/equalityBundle.js: j2/basicTypesBundle.js j2/intrinsic.js
 j2/errormessages.js: j2/util.js j2/standard.js

--- a/Makefile.mgDependencies
+++ b/Makefile.mgDependencies
@@ -78,6 +78,7 @@ j2/minitest.js: j2/minitestBundle.js
 j2/minitestBundle.js: j2/standardBundle.js j2/gUnit.js
 j2/nospec.js: j2/standard.js
 j2/notest.js: j2/standard.js
+j2/objectdraw.js: j2/random.js j2/standard.js
 j2/option.js: j2/standard.js
 j2/random.js: j2/standard.js
 j2/requireTypes.js: j2/dialect.js j2/standard.js

--- a/compiler.grace
+++ b/compiler.grace
@@ -37,7 +37,7 @@ method compileInputFile {
         }
 
         var moduleObject := parser.parse(tokens)
-
+        tokens := false     // release the memory
         var values := moduleObject.value
 
         if (util.target == "parse") then {

--- a/genjs.grace
+++ b/genjs.grace
@@ -8,7 +8,7 @@ import "xmodule" as xmodule
 import "errormessages" as errormessages
 import "identifierresolution" as identifierresolution
 import "identifierKinds" as k
-import "fastDict" as map
+import "mapDict" as map
 import "shasum" as shasum
 import "buildinfo" as buildinfo
 import "regularExpression" as regex
@@ -533,7 +533,7 @@ method compiletypedec(o) in (obj) {
             // Why unknownType, rather than typeType?  Because the latter will
             // compile a check that the return value is actually a type, which
             // causes a circularity when trying to import collections. The check
-            // is also unnecessary, if the type operators are correctly implemented.
+            // is subsumed by a call to `isType` in the body of `setTypeName`
     typeMethod.isOnceMethod := true
     typeMethod.withTypeParams(o.typeParams)
     s.node := originalNode       // gct generation will scan the ast after code is generated

--- a/genjs.grace
+++ b/genjs.grace
@@ -546,7 +546,7 @@ method typeFunBody(typeExpr) named (tName) {
         // this guard prevents us from renaming the rhs in decls like type A⟦T⟧ = B⟦T⟧
         [ ast.callNode.new(
                 typeExpr,
-                [ast.requestPart.request "setName"
+                [ast.requestPart.request "setTypeName"
                      withArgs[ ast.stringNode.new(tName) ] ]
         ).onSelf ]
     } else {

--- a/identifierresolution.grace
+++ b/identifierresolution.grace
@@ -8,7 +8,7 @@ import "sys" as sys
 import "ast" as ast
 import "util" as util
 import "xmodule" as xmodule
-import "fastDict" as map
+import "mapDict" as map
 import "errormessages" as errormessages
 import "identifierKinds" as k
 import "mirror" as mirror

--- a/identifierresolution.grace
+++ b/identifierresolution.grace
@@ -890,7 +890,9 @@ method generateGctForModule(module) {
     gct.at "methods" put (methodList.sort)
     gct.at "types" put (typeList.sort)
     gct.at "modules" put (xmodule.externalModules.keys.sorted)
-    gct.at "methodTypes" put (ms.methodTypes.values.sorted)
+    ms.methodTypes.keysAndValuesDo { methodName, methodType ->
+        gct.at "methodType:{methodName}" put [methodType]
+    }
     def p = util.infile.pathname
     gct.at "path" put [ if (p.isEmpty) then {
         ""

--- a/js/gracelib.js
+++ b/js/gracelib.js
@@ -782,6 +782,9 @@ GraceString.prototype = {
                                    accum, new GraceString(self[ix]));
             }
             return accum;
+        },
+        "isType": function(argcv) {
+            return GraceFalse;
         }
     },
     className: "string",
@@ -1103,6 +1106,9 @@ GraceNum.prototype = {
         },
         "prefix¬": function(argcv) {
             return graceNotPattern(this);
+        },
+        "isType": function(argcv) {
+            return GraceFalse;
         }
     },
     className: "number",
@@ -1229,6 +1235,9 @@ GraceBoolean.prototype = {
         },
         "hash": function(argcv) {
             return new GraceNum(this._value ? 3637 : 1741);
+        },
+        "isType": function(argcv) {
+            return GraceFalse;
         }
     },
     className: "boolean",

--- a/js/gracelib.js
+++ b/js/gracelib.js
@@ -1809,6 +1809,12 @@ function GraceTypeVariant(l, r) {
 function GraceTypeSubtraction(l, r) {
     return request(patternAndType(), "TypeSubtraction(2)", [2], l, r);
 }
+function type_setName (argcv, nu) {
+    if (nu.className !== "string") nu = request(nu, "asString", [0]);
+    this.name = nu._value;
+    return this;
+}
+type_setName.confidential = true;
 
 function GraceType(name) {
     this.name = name;
@@ -1877,10 +1883,9 @@ GraceType.prototype = {
         "hash": function type_hash (argcv) {
             return selfRequest(this, "myIdentityHash", argcv)
         },
-        "setName(1)": function type_setName (argcv, nu) {
-            if (nu.className !== "string") nu = request(nu, "asString", [0]);
-            this.name = nu._value;
-            return this;
+        "setName(1)": type_setName,
+        "setTypeName(1)": function type_setTypeName (argcv, nu) {
+            return type_setName.call(this, argcv, nu)
         },
         "name": function type_name (argcv) {
             return new GraceString(this.name);

--- a/js/tests/dictionaryTest.grace
+++ b/js/tests/dictionaryTest.grace
@@ -447,7 +447,7 @@ trait dictionaryTest {
         }
         method testDictionaryAnySatisfy {
             assert (oneToFive.anySatisfy { x -> (x/2).isEven })
-                description "oneToFive does not any element x s.t. x/2 is even"
+                description "oneToFive does not contain an x s.t. x/2 is even"
             deny (empty.anySatisfy {_ -> true})
                 description "empty includes some element!"
             deny (oneToFive.anySatisfy {x -> x > 5})

--- a/js/tests/t007_types+objects_test.grace
+++ b/js/tests/t007_types+objects_test.grace
@@ -5,17 +5,26 @@ testSuite "standard types and objects" with {
     test "numbers have type Number" by {
         assert 3 hasType (Number)
     }
+    test "numbers have type Pattern" by {
+        assert 3 hasType (Pattern)
+    }
     test "Number describes numbers" by {
         assertType (Number) describes 3
     }
     test "strings have type String" by {
         assert "test" hasType (String)
     }
+    test "strings have type Pattern" by {
+        assert "test" hasType (Pattern)
+    }
     test "String describes strings" by {
         assertType (String) describes "test"
     }
     test "booleans have type Boolean" by {
         assert true hasType (Boolean)
+    }
+    test "booleans have type Pattern" by {
+        assert true hasType (Pattern)
     }
     test "Boolean describes booleans" by {
         assertType (Boolean) describes true
@@ -35,8 +44,17 @@ testSuite "standard types and objects" with {
     test "Pattern describes AndPattern" by {
         assertType (Pattern) describes (>3 & <10)
     }
+    test "OrPatterns have type Pattern" by {
+        assert (<3 | >10) hasType (Pattern)
+    }
+    test "Pattern describes OrPattern" by {
+        assertType (Pattern) describes (<3 | >10)
+    }
     test "UninitializedVariable has type ExceptionKind" by {
         assert (UninitializedVariable) hasType (ExceptionKind)
+    }
+    test "UninitializedVariable has type Pattern" by {
+        assert (UninitializedVariable) hasType (Pattern)
     }
     test "ExceptionKind describes UninitializedVariable" by {
         assertType (ExceptionKind) describes (UninitializedVariable)

--- a/js/tests/t147_mapDict_test.grace
+++ b/js/tests/t147_mapDict_test.grace
@@ -1,0 +1,23 @@
+dialect "standard"
+import "gUnit" as gU
+import "mapDict" as md
+import "dictionaryTest" as dictionaryTest
+
+def ConcurrentModification is public = ProgrammingError.refine "ConcurrentModification"
+
+trait fastDictTest {
+    class forMethod(m) {
+        inherit dictionaryTest.dictionaryTest.forMethod(m)
+
+        method dictionaryUnderTestWith (bindings) is override {
+            md.dictionary⟦String, Number⟧.withAll (bindings)
+        }
+        method dictionaryUnderTestEmpty { md.dictionary.empty }
+        method dictionaryUnderTestFactory { md.dictionary }
+    }
+}
+
+def dictTests = gU.testSuite.fromTestMethodsIn(fastDictTest) named "dictionaryTest"
+dictTests.runAndPrintResults
+
+gU.exit

--- a/js/tests/t147_mapDict_test.grace
+++ b/js/tests/t147_mapDict_test.grace
@@ -5,7 +5,7 @@ import "dictionaryTest" as dictionaryTest
 
 def ConcurrentModification is public = ProgrammingError.refine "ConcurrentModification"
 
-trait fastDictTest {
+trait mapDictTest {
     class forMethod(m) {
         inherit dictionaryTest.dictionaryTest.forMethod(m)
 
@@ -17,7 +17,7 @@ trait fastDictTest {
     }
 }
 
-def dictTests = gU.testSuite.fromTestMethodsIn(fastDictTest) named "dictionaryTest"
+def dictTests = gU.testSuite.fromTestMethodsIn(mapDictTest) named "dictionaryTest"
 dictTests.runAndPrintResults
 
 gU.exit

--- a/js/tests/t157_block_test.grace
+++ b/js/tests/t157_block_test.grace
@@ -1,0 +1,110 @@
+dialect "minispec"
+
+def truthy = object {
+    use equality
+    use BasePattern
+    method ifTrue(action) { action.apply }
+    method ifFalse(action) { done }
+    method ifTrue(action)ifFalse(_) { action.apply }
+    method ifFalse(_)ifTrue(action) { action.apply }
+    method asString { "not a Boolean, but behaves like true" }
+    method hash { true.hash }
+    method == (other) {
+        match (other)
+            case {b:Boolean -> b}
+            else { false }
+    }
+    method not { falsy }
+    method prefix ! { falsy }
+    method &&(other) {
+        match (other)
+            case {tv:Boolean -> tv }
+            case {block:Procedure0 -> block.apply}
+    }
+    method ||(other) { self }
+    method matches(o) { self == o }
+
+}
+def falsy = object {
+    use equality
+    use BasePattern
+    method ifFalse(action) { action.apply }
+    method ifTrue(action) { done }
+    method ifFalse(action)ifTrue(_) { action.apply }
+    method ifTrue(_)ifFalse(action) { action.apply }
+    method asString { "not a Boolean, but behaves like false" }
+    method hash { false.hash }
+    method == (other) {
+        match (other)
+            case {b:Boolean -> b.not}
+            else { false }
+    }
+    method not { truthy }
+    method prefix ! { truthy }
+    method &&(other) { self }
+    method ||(other) {
+        match (other)
+            case {tv:Boolean -> tv }
+            case {block:Procedure0 -> block.apply}
+    }
+    method matches(o) { self == o }
+}
+
+method pass { assert(true) }
+
+describe "alternative truth values" with {
+    specify "type of truthy" by {
+        expect (truthy) toHaveType (Boolean)
+        expect (truthy) toHaveType (Pattern)
+    }
+    specify "type of falsy" by {
+        expect (falsy) toHaveType (Boolean)
+        expect (falsy) toHaveType (Pattern)
+    }
+    specify "if truthy happens" by {
+        if (truthy) then {
+            pass
+        } else {
+            failAndSay "truthy took the else branch"
+        }
+    }
+    specify "if falsy happens" by {
+        if (falsy) then {
+            failAndSay "falsy took the then branch"
+        } else {
+            pass
+        }
+    }
+    specify "and" by {
+       expect (falsy && true) toBe false
+       expect (falsy && false) toBe false
+       expect (truthy && true) toBe true
+       expect (truthy && false) toBe false
+       expect (false && truthy) toBe false
+       expect (false && falsy) toBe false
+       expect (true && truthy) toBe true
+       expect (true && falsy) toBe false
+    }
+    specify "or" by {
+       expect (falsy || true) toBe true
+       expect (falsy || false) toBe false
+       expect (truthy || true) toBe true
+       expect (truthy || false) toBe true
+       expect (false || truthy) toBe true
+       expect (false || falsy) toBe false
+       expect (true || truthy) toBe true
+       expect (true || falsy) toBe true
+    }
+    specify "equality" by {
+       expect (falsy == true) toBe false
+       expect (falsy == false) toBe true
+       expect (truthy == true) toBe true
+       expect (truthy == false) toBe false
+       expect (false == truthy) toBe false
+       expect (false == falsy) toBe true
+       expect (true == truthy) toBe true
+       expect (true == falsy) toBe false
+    }
+}
+
+exit

--- a/lexer.grace
+++ b/lexer.grace
@@ -120,7 +120,7 @@ method initialize {
 }
 
 var tokens                  // a linked-list of output tokens
-var lastNonCommentToken     // the most last token pushed that was not a comment
+var lastNonCommentToken     // the most recent token pushed that was not a comment
 var lineNumber              // the current input line number
 var linePosition            // the character position on the input line
 var startLine               // the line on which the current token starts
@@ -1593,5 +1593,8 @@ method lexInputLines {
             atRange(startLine, stringStart, inputLines.at(startLine).size)
     }
     tokens.push(eofToken)
-    tokens
+    def result = tokens
+    tokens := object {}
+    lastNonCommentToken := object {}
+    result
 }

--- a/lexer.grace
+++ b/lexer.grace
@@ -2,7 +2,7 @@ dialect "standard"
 import "util" as util
 import "unicode" as unicode
 import "errormessages" as errormessages
-import "fastDict" as map
+import "mapDict" as map
 import "regularExpression" as re
 
 def keywords = map.dictionary.empty

--- a/mapDict.grace
+++ b/mapDict.grace
@@ -1,0 +1,441 @@
+dialect "none"
+import "collections" as collections
+import "intrinsic" as intrinsic
+
+use intrinsic.annotations
+
+def ConcurrentModification is public =
+    intrinsic.constants.ProgrammingError.refine "ConcurrentModification"
+
+type Binding⟦K,T⟧ = collections.Binding⟦K,T⟧
+type Collection⟦T⟧ = collections.Collection⟦T⟧
+def NoSuchObject = collections.NoSuchObject
+def IteratorExhausted = collections.IteratorExhausted
+
+def prims = object {
+    method emptyJSMap {
+        native "js" code ‹return new Map();
+    ›
+    }
+}
+
+def removed = object {
+    // Used as a tombestone to mark the location of a removed VALUE.
+    // The key, and the key-value binding object, remain in the dictionary
+    method asString { "removed" }
+    method == (other) { self.isMe(other) }
+    method ≠ (other) { self.isMe(other).not }
+    method hash { self.myIdentityHash }
+}
+
+class dictionary⟦K,T⟧ {
+
+    method asString { "the dictionary factory" }
+
+    method with(aBinding) {
+        empty.add(aBinding)
+    }
+
+    method withAll(initialBindings: Collection⟦Binding⟦K,T⟧⟧) {
+        // we can't say -> Dictionary⟦K,T⟧, because checking that (dynamically)
+        // requires building a dictionary for the memo table in the Dictionary type
+
+        def result = empty
+        initialBindings.do { b:Binding -> result.add(b) }
+        result
+    }
+    
+    method << (source:Collection⟦Binding⟦K,T⟧⟧) { self.withAll(source) }
+
+    class empty {
+
+        use collections.collection⟦T⟧
+        var mods is readable := 0
+        var numBindings := 0
+        var table := prims.emptyJSMap
+
+        method size { numBindings }
+
+        method at (k) put (v) {
+            mods := mods + 1
+            native "js" code ‹var hc = request(var_k, "hash", [0])._value;
+                while (true) {
+                    let b = this.data.table.get(hc)
+                    if (! b) break;  // get answers undedined if the key is not present
+                    if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                        if (var_removed === b.value) {
+                            this.data.numBindings = new GraceNum(this.data.numBindings._value + 1);
+                        }   // otherwise, we are overwriting an existing binding
+                        b.value = var_v;
+                        return this;
+                    }
+                    hc++;
+                }
+                this.data.table.set(hc, {key: var_k, value: var_v});
+                this.data.numBindings = new GraceNum(this.data.numBindings._value + 1);
+                return this;
+            ›
+        }
+        method add(aBinding) {
+            self.at (aBinding.key) put (aBinding.value)
+        }
+        method addAll(bindings) {
+            bindings.do{ each -> add(each) }
+            self    // for chaining
+        }
+        method at(k) {
+            native "js" code ‹
+            var hc = request(var_k, "hash", [0])._value;
+            while (true) {
+                let b = this.data.table.get(hc);
+                if (! b) break;
+                if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                    if (var_removed === b.value) break;
+                    return b.value;
+                }
+                hc++;
+            }›
+            NoSuchObject.raise "dictionary does not contain entry with key {k}"
+        }
+        method at(k) ifAbsent(action) {
+            native "js" code ‹
+            var hc = request(var_k, "hash", [0])._value;
+            while (true) {
+                let b = this.data.table.get(hc);
+                if (! b) break;
+                if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                    if (var_removed === b.value) break;
+                    return b.value;
+                }
+                hc++;
+            }›
+            action.apply
+        }
+        method containsKey(k) {
+            native "js" code ‹
+            var hc = request(var_k, "hash", [0])._value;
+            while (true) {
+                let b = this.data.table.get(hc);
+                if (! b) break;
+                if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                    return (var_removed === b.value ? GraceFalse : GraceTrue);
+                }
+                hc++;
+            };
+            return GraceFalse;›
+        }
+        method removeAllKeys(keys) {
+            mods := mods + 1
+            keys.do { k → removeKey(k) }
+            self
+        }
+        method removeKey(k) {
+            mods := mods + 1
+            native "js" code ‹
+            var hc = request(var_k, "hash", [0])._value;
+            while (true) {
+                let b = this.data.table.get(hc);
+                if (! b) break;
+                if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                    if (var_removed === b.value) break;
+                    b.value = var_removed;
+                    this.data.numBindings = new GraceNum(this.data.numBindings._value - 1);
+                    return this;
+                }
+                hc++;
+            };›
+            NoSuchObject.raise "dictionary does not contain entry with key {k}"
+        }
+        method removeKey(k) ifAbsent (action) {
+            mods := mods + 1
+            native "js" code ‹
+            var hc = request(var_k, "hash", [0])._value;
+            while (true) {
+                let b = this.data.table.get(hc);
+                if (! b) break;
+                if (Grace_isTrue(request(b.key, "==(1)", [1], var_k))) {
+                    if (var_removed === b.value) break;
+                    b.value = var_removed;
+                    this.data.numBindings = new GraceNum(this.data.numBindings._value - 1);
+                    return this;
+                }
+                hc++;
+            };›
+            action.apply
+        }
+        method removeAllValues(removals) {
+            // remove all bindings with any of the values in removals
+            mods := mods + 1
+            native "js" code ‹
+            let t = this.data.table
+            for (let b of t.values()) {
+                if (Grace_isTrue(request(var_removals, 'contains(1)', [1], b.value))) {
+                    b.value = var_removed;
+                    this.data.numBindings = new GraceNum(this.data.numBindings._value - 1);
+                }
+            };›
+            self
+        }
+        method removeValue(v) {
+            // remove all bindings with value v
+            mods := mods + 1
+            def initialNumBindings = numBindings
+            native "js" code ‹
+            let t = this.data.table
+            for (let b of t.values()) {
+                if (Grace_isTrue(request(var_v, '==(1)', [1], b.value))) {
+                    b.value = var_removed;
+                    this.data.numBindings = new GraceNum(this.data.numBindings._value - 1);
+                }
+            };›
+            if (numBindings == initialNumBindings) then {
+                NoSuchObject.raise "dictionary does not contain any entries with value {v}"
+            }
+            self
+        }
+        method removeValue(v) ifAbsent (action) {
+            // remove all bindings with value v
+            mods := mods + 1
+            def initialNumBindings = numBindings
+            native "js" code ‹
+            let t = this.data.table
+            for (let b of t.values()) {
+                if (Grace_isTrue(request(var_v, '==(1)', [1], b.value))) {
+                    b.value = var_removed;
+                    this.data.numBindings = new GraceNum(this.data.numBindings._value - 1);
+                }
+            };›
+            if (numBindings == initialNumBindings) then {
+                action.apply
+            }
+            self
+        }
+        method clear { 
+            native "js" code ‹this.data.table.clear();›
+            numBindings := 0
+            mods := mods + 1
+            self
+        }
+        method containsValue(v) {
+            self.valuesDo{ each ->
+                if (v == each) then { return true }
+            }
+            false
+        }
+        method contains(v) { containsValue(v) }
+        method asString {
+            // do()separatedBy won't work, because it iterates over values,
+            // and we need an iterator over bindings.
+            native "js" code ‹
+            var s = "dictionary [";
+            var first = true;
+            let t = this.data.table;
+            for (let p of t.values()) {
+                if (var_removed !== p.value) {
+                    if (first)
+                        first = false;
+                    else
+                        s += ", ";
+                    s += request(p.key, "asString", [0])._value;
+                    s += "::";
+                    s += request(p.value, "asString", [0])._value;
+                }
+            }
+            s += "]";
+            return new GraceString(s);
+        ›
+        }
+        method asDebugString {
+            native "js" code ‹
+            var s = "mapDict⟬";
+            var first = true;
+            let t = this.data.table;
+            for (let p of t.values()) {
+                if (first)
+                    first = false;
+                else
+                    s += ", ";
+                s += request(p.key, "asDebugString", [0])._value;
+                s += "::";
+                s += request(p.value, "asDebugString", [0])._value;
+            }
+            s += "⟭";
+            return new GraceString(s);
+        ›
+        }
+        method keys  {
+            def sourceDictionary = self
+            object {
+                use collections.enumerable⟦K⟧
+                class iterator {
+                    def sourceIterator = sourceDictionary.bindingsIterator
+                    method hasNext { sourceIterator.hasNext }
+                    method next { sourceIterator.next.key }
+                    method asString {
+                        "an iterator over keys of {sourceDictionary}"
+                    }
+                }
+                def size is public = sourceDictionary.size
+                method asDebugString {
+                    "a lazy sequence over keys of {sourceDictionary}"
+                }
+            }
+        }
+        method values {
+            def sourceDictionary = self
+            object {
+                use collections.enumerable⟦T⟧
+                class iterator {
+                    def sourceIterator = sourceDictionary.bindingsIterator
+                    // should be request on outer
+                    method hasNext { sourceIterator.hasNext }
+                    method next { sourceIterator.next.value }
+                    method asString {
+                        "an iterator over values of {sourceDictionary}"
+                    }
+                }
+                def size is public = sourceDictionary.size
+                method asDebugString {
+                    "a lazy sequence over values of {sourceDictionary}"
+                }
+            }
+        }
+        method bindings {
+            def sourceDictionary = self
+            object {
+                use collections.enumerable⟦T⟧
+                method iterator { sourceDictionary.bindingsIterator }
+                // should be request on outer
+                def size is public = sourceDictionary.size
+                method asDebugString {
+                    "a lazy sequence over bindings of {sourceDictionary}"
+                }
+            }
+        }
+        method iterator { values.iterator }
+        class bindingsIterator {
+            // this should be confidential, but can't be until `outer` is fixed.
+            def iMods = mods
+            var count := 1
+            def subjectDictionary = outer;
+            native "js" code ‹this.data.allTheKeys = this.data.subjectDictionary.data.table.keys();
+            ›
+            method hasNext { size >= count }
+            method next {
+                if (iMods != mods) then {
+                    ConcurrentModification.raise (outer.asString)
+                }
+                if (size < count) then { IteratorExhausted.raise "over {outer.asString}" }
+                native "js" code ‹
+                let binding = request(var_collections, 'binding', [0]);
+                while (true) {
+                    let iResult = this.data.allTheKeys.next();
+                    if (iResult.done) break;
+                    let nextKey = iResult.value
+                    let b = this.data.subjectDictionary.data.table.get(nextKey);
+                        if (var_removed !== b.value) {
+                            this.data.count = new GraceNum(this.data.count._value + 1);
+                            return request(binding, 'key(1)value(1)',  [1,1], b.key, b.value);
+                        }
+                }
+                console.warn("broke out of bindingsIterator while loop");
+                ›
+                IteratorExhausted.raise "(JSIterator) over {outer.asString}"
+            }
+        }
+        method keysAndValuesDo(block2) {
+            native "js" code ‹
+            let t = this.data.table;
+            let iMods = this.data.mods._value;
+            for (let p of t.values()) {
+                if (var_removed !== p.value) {
+                    if (iMods !== this.data.mods._value)
+                        request(var_ConcurrentModification, "raise(1)", [1], request(this, "asDebugString", [0]));
+                    request(var_block2, 'apply(2)', [2], p.key, p.value);
+                }
+            }
+            ›
+        }
+        method keysDo(block1) {
+            native "js" code ‹
+            let t = this.data.table;
+            let iMods = this.data.mods._value;
+            for (let p of t.values()) {
+                if (var_removed !== p.value) {
+                    if (iMods !== this.data.mods._value)
+                        request(var_ConcurrentModification, "raise(1)", [1], request(this, "asDebugString", [0]));
+                    request(var_block1, 'apply(1)', [1], p.key);
+                }
+            }
+            ›
+        }
+        method valuesDo(block1) {
+            native "js" code ‹
+            let t = this.data.table;
+            let iMods = this.data.mods._value;
+            for (let p of t.values()) {
+                if (var_removed != p.value) {
+                    if (iMods !== this.data.mods._value)
+                        request(var_ConcurrentModification, "raise(1)", [1], request(this, "asDebugString", [0]));
+                    request(var_block1, 'apply(1)', [1], p.value);
+                }
+            }
+            ›
+        }
+        method do(block1) { valuesDo(block1) }
+
+        method ==(other) {
+            match (other) case { o:collections.ComparableToDictionary⟦K,T⟧ ->
+                if (self.size != o.size) then {return false}
+                self.keysAndValuesDo { k, v ->
+                    if (o.at(k)ifAbsent{return false} != v) then {
+                        return false
+                    }
+                }
+                return true
+            } else {
+                return false
+            }
+        }
+        method ≠ (other) { (self == other).not }
+
+        method copy {
+            def newCopy = dictionary.empty
+            self.keysAndValuesDo{ k, v ->
+                newCopy.at(k)put(v)
+            }
+            newCopy
+        }
+
+
+        method ++ (other:Collection⟦T⟧) {
+            // answers a new dictionary containing all my keys and the keys of other;
+            // if other contains one of my keys, other's value overrides mine
+            def newDict = self.copy
+            other.keysAndValuesDo {k, v ->
+                newDict.at(k) put(v)
+            }
+            return newDict
+        }
+
+        method -- (other:Collection⟦T⟧) {
+            // answers a new dictionary like me but excluding the keys of other
+            def newDict = dictionary.empty
+            keysAndValuesDo { k, v ->
+                if (! other.containsKey(k)) then {
+                    newDict.at(k) put(v)
+                }
+            }
+            return newDict
+        }
+
+        method >>(target) is override {
+            target << self.bindings
+        }
+
+        method <<(source) is override {
+            self.addAll(source)
+        }
+    }
+}
+

--- a/modules/tests/typeComparison_test.grace
+++ b/modules/tests/typeComparison_test.grace
@@ -15,7 +15,7 @@ testSuite {
 
     test "coverage – false and Iterable" by {
         assert(tc.protocolOf (false) notCoveredBy (Object)) shouldBe
-            "&&(_), &(_), ::(_), ==(_), hash, ifFalse(_), ifFalse(_)ifTrue(_), ifTrue(_), ifTrue(_)ifFalse(_), matches(_), not, prefix!, prefix¬, |(_), ||(_), and ≠(_)"
+            "&&(_), &(_), ::(_), ==(_), hash, ifFalse(_), ifFalse(_)ifTrue(_), ifTrue(_), ifTrue(_)ifFalse(_), isType, matches(_), not, prefix!, prefix¬, |(_), ||(_), and ≠(_)"
     }
     test "coverage – done and Object" by {
         assert(tc.protocolOf (done) notCoveredBy (Done)) shouldBe ""

--- a/parser.grace
+++ b/parser.grace
@@ -6,7 +6,7 @@ import "errormessages" as errormessages
 
 var tokens := false
 var moduleObject
-var comments := list.empty   // so we can request `removeAt`
+def comments = list.empty   // so we can request `removeAt`
 
 var auto_count := 0
 def noBlocks = false
@@ -3217,5 +3217,12 @@ method parse(toks) {
         }
         separator
     }
-    return moduleObject
+    def result = moduleObject
+    tokens := object {}
+    moduleObject := {}
+    sym := object {}
+    lastToken := object {}
+    statementToken := object {}
+    comments.clear
+    result
 }

--- a/pattern+typeBundle.grace
+++ b/pattern+typeBundle.grace
@@ -22,6 +22,12 @@ trait open {
             NotPattern(self)
         }
         method isType { false }
+        method setTypeName(_) is confidential {
+            // This method exists so that if compiled code tries to setTypeName
+            // on a pattern, we will get a nicer error than NoSuchMethod.
+            // It is confidetial so that it does not show up in the Pattern type.
+            intrinsic.constants.TypeError.raise "{self} is a Pattern, but not a Type"
+        }
     }
 
     trait AndPattern(p1, p2) {
@@ -54,8 +60,11 @@ trait open {
         method -(o) { TypeSubtraction(self, o) }
         method asString { "type {self.name}" }
         method setName(nu) is confidential {
-            self.name:=(nu)
-            return self     // for chaining
+            self.name := nu
+            self     // for chaining
+        }
+        method setTypeName(nu) {
+            self.setName(nu)
         }
         method matchHook(obj) is required   // does the actual matching
         method matches(obj) {
@@ -121,6 +130,7 @@ trait open {
             exclude |(_)
             exclude matches(_)
             exclude isType
+            exclude setTypeName(_)
         use BaseType
         var name is readable := "‹anon›"
         method methodNames {
@@ -148,6 +158,7 @@ trait open {
             exclude |(_)
             exclude matches(_)
             exclude isType
+            exclude setTypeName(_)
         use BaseType
         var name is readable := "‹anon›"
         method methodNames {

--- a/prefixTree.grace
+++ b/prefixTree.grace
@@ -6,7 +6,7 @@ dialect "standard"
 // all prefixes, i.e., [], [a] and [a, b], even though it has size 1
 // The empty prefix tree contains the empty sequence.
 
-import "fastDict" as fd
+import "mapDict" as d
 
 def end = object {
     inherit singleton "end"
@@ -17,7 +17,7 @@ def end = object {
 
 class prefixTree {
     // answers an empty prefix tree
-    def dict = fd.dictionary.empty
+    def dict = d.dictionary.empty
     
     method add (entry:Collection) {
         add (entry) index 1

--- a/util.grace
+++ b/util.grace
@@ -2,7 +2,7 @@ dialect "standard"
 import "io" as io
 import "sys" as sys
 import "unixFilePath" as filePath
-import "fastDict" as map
+import "mapDict" as map
 
 def defaultVerbosity is public = 30
 def defaultTarget is public = "js"

--- a/xmodule.grace
+++ b/xmodule.grace
@@ -154,14 +154,9 @@ method printBacktrace(exceptionPacket) asFarAs (methodName) {
     def msg = exceptionPacket.message
     def lineNr = exceptionPacket.lineNumber
     def mod = exceptionPacket.moduleName
-    if (lineNr == 0) then {
-        io.error.write "{ex} in {mod}: {msg}\n"
-    } else {
-        io.error.write "{ex} on line {lineNr} of {mod}: {msg}\n"
-    }
+    io.error.write "{ex}: {msg}\n"
     def bt = exceptionPacket.backtrace
-    while {bt.size > 0} do {
-        def frameDescription = bt.pop
+    bt.reversed.do { frameDescription ->
         io.error.write "  requested from {frameDescription}\n"
         if (frameDescription.contains(methodName)) then { return }
     }

--- a/xmodule.grace
+++ b/xmodule.grace
@@ -9,7 +9,7 @@ import "unixFilePath" as filePath
 import "shasum" as shasum
 import "regularExpression" as regex
 import "buildinfo" as buildinfo
-import "fastDict" as fd
+import "mapDict" as mapDict
 import "intrinsic" as intrinsic
 
 def CheckerFailure = Exception.refine "CheckerFailure"
@@ -42,8 +42,8 @@ type RangeSuggestions = {
     suggestions
 }
 
-def externalModules is public = fd.dictionary.empty  // dialect & direct imports
-def transitiveModules = fd.dictionary.empty          // transitive imports
+def externalModules is public = mapDict.dictionary.empty  // dialect & direct imports
+def transitiveModules = mapDict.dictionary.empty          // transitive imports
 
 type ModuleRecord = interface {  // a record describing an external module
     path -> filePath.FilePath    // the path to the source file


### PR DESCRIPTION
Currently, methodTypes are placed in a single GCT entry. We are having issues with parsing that in case there is a method types that spans multiple lines. One example of such method type,  `myMethWithParam`, is listed below. This pull request separates each method type into an individual entry in a GCT file with a key name `methodType-of:`, followed by an actual method type name.

```
method myMethWithParam(myParam : interface{
    m(param : MyType) -> Number
    n -> String
}) -> String { myParam.n 
```